### PR TITLE
Add support for the payment message event

### DIFF
--- a/src/incoming.js
+++ b/src/incoming.js
@@ -129,7 +129,7 @@ module.exports = (bp, messenger) => {
       const recipient = pending.event.raw.to
       if (e.sender.id === recipient) {
         if (pending.event.raw.waitRead
-          && pending.timestamp 
+          && pending.timestamp
           && pending.timestamp <= e.read.watermark) {
           pending.resolve(e)
           delete outgoing.pending[pending.event.__id]
@@ -174,6 +174,20 @@ module.exports = (bp, messenger) => {
         type: 'referral',
         user: profile,
         text: e.referral.ref,
+        raw: e
+      })
+    })
+  })
+
+  messenger.on('payment', e=> {
+    preprocessEvent(e)
+    .then(profile=> {
+      bp.middlewares.sendIncoming({
+        platform: 'facebook',
+        type: 'payment',
+        text: 'payment',
+        user: profile,
+        payment: e.payment,
         raw: e
       })
     })

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -472,7 +472,10 @@ class Messenger extends EventEmitter {
             this._handleEvent('optin', event)
           } else if (event.referral) {
             this._handleEvent('referral', event)
-          } else {
+          } else if (event.payment){
+            this._handleEvent('payment', event)
+          }
+          else {
             console.log('Webhook received unknown event: ', event)
           }
         })


### PR DESCRIPTION
Allows the chatbot to listen and respond to payment event types from
facebook.

For more information:

- https://developers.facebook.com/docs/messenger-platform/complete-guide/payments
- https://developers.facebook.com/docs/messenger-platform/webhook-reference/payment

The first link describes how to facilitate a payment via Facebook Messenger.  The second describes the message event that Facebook sends back to your bot.  You already have the ability to send the Buy Button, but you need to ability to process the payment event response.