### PR TITLE
Bugfix on image_url param to quick replies

### DIFF
--- a/src/messenger.js
+++ b/src/messenger.js
@@ -353,7 +353,8 @@ class Messenger extends EventEmitter {
         return {
           content_type: reply.content_type || 'text',
           title: reply.title,
-          payload: reply.payload || 'QR_' + normalizeString(reply.title)
+          payload: reply.payload || 'QR_' + normalizeString(reply.title),
+          image_url: reply.image_url
         }
       }
       return {}


### PR DESCRIPTION
Users can send `image_url` param to quick replies now.