### PR TITLE
Adding a custom postback payload on Get Started

### DIFF
--- a/src/incoming.js
+++ b/src/incoming.js
@@ -79,8 +79,19 @@ module.exports = (bp, messenger) => {
 
       if (e.postback.payload === 'GET_STARTED') {
         const mConfig = messenger.getConfig()
-        if (mConfig.displayGetStarted && mConfig.autoRespondGetStarted) {
-          bp.messenger.sendText(profile.id, mConfig.autoResponse)
+
+        if (mConfig.displayGetStarted && mConfig.autoResponseOption == 'autoResponseText') {
+          bp.messenger.sendText(profile.id, mConfig.autoResponseText)
+        }
+        
+        if (mConfig.displayGetStarted && mConfig.autoResponseOption == 'autoResponsePostback') {
+          bp.middlewares.sendIncoming({
+            platform: 'facebook',
+            type: 'postback',
+            user: profile,
+            text: mConfig.autoResponsePostback,
+            raw: e
+          })
         }
       }
     })

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,11 @@ module.exports = {
     targetAudienceOpenToSome: { type: 'string', required: false },
     targetAudienceCloseToSome: { type: 'string', required: false },
     trustedDomains: { type: 'any', required: false, default: [], validation: v => _.isArray(v) },
-    autoRespondGetStarted: { type: 'bool', required: false, default: true },
-    autoResponse: { type: 'string', required: false, default: 'Hello!' }
+    autoRespondGetStarted: { type: 'bool', required: false, default: true }, // deprecated
+    autoResponse: { type: 'string', required: false, default: 'Hello!' },     // deprecated
+    autoResponseOption: { type: 'string', required: false, default: 'noResponse' },
+    autoResponseText: { type: 'string', required: false, default: 'Hello, human!' },
+    autoResponsePostback: { type: 'string', required: false, default: 'YOUR_POSTBACK' }
   },
 
   init: function(bp) {

--- a/src/views/index.jsx
+++ b/src/views/index.jsx
@@ -257,10 +257,35 @@ export default class MessengerModule extends React.Component {
   }
 
   renderGetStartedMessage() {
-    return <div>
-      {this.renderCheckBox('Auto respond to GET_STARTED postback', 'autoRespondGetStarted', this.state.homepage+'#display-get-started')}
-      {this.state.autoRespondGetStarted && this.renderTextAreaInput('Auto response', 'autoResponse', this.state.homepage+'#greeting-message')}
-    </div>
+    return (
+      <FormGroup>
+        {this.renderLabel('Get Started Auto Response?', this.state.homepage+'#display-get-started')}
+        <Col sm={7}>
+          <Radio name="autoResponseOption" value="noResponse" checked={this.state.autoResponseOption === "noResponse"} onChange={this.handleChange}>No auto response</Radio>
+          <Radio name="autoResponseOption" value="autoResponseText" checked={this.state.autoResponseOption === "autoResponseText"} onChange={this.handleChange}>Text response</Radio>
+          { this.state.autoResponseOption == "autoResponseText" &&
+            <FormGroup className={style.insideRadioFormGroup}>
+              <Col sm={12}>
+                <FormControl name="autoResponseText"
+                  componentClass="textarea" rows="3"
+                  value={this.state['autoResponseText']}
+                  onChange={this.handleChange} />
+                <HelpBlock>Define an auto response text to <em>Get Started</em> postback</HelpBlock>
+              </Col>
+            </FormGroup>
+          }
+          <Radio name="autoResponseOption" value="autoResponsePostback" checked={this.state.autoResponseOption === "autoResponsePostback"} onChange={this.handleChange}>Trigger a postback</Radio>
+          { this.state.autoResponseOption == "autoResponsePostback" &&
+            <FormGroup className={style.insideRadioFormGroup}>
+              <Col sm={12}>
+                <FormControl name="autoResponsePostback" type="text" value={this.state['autoResponsePostback']} onChange={this.handleChange} />
+                <HelpBlock><strong>{this.state.autoResponsePostback}</strong> postback will be triggered automatically on <em>Get Started</em> event.</HelpBlock>
+              </Col>
+            </FormGroup>
+          }
+        </Col>
+      </FormGroup>
+    )
   }
 
   renderHostnameTextInput(props) {


### PR DESCRIPTION
Now you can define a custom postback to _Get Started_ event in according to issue https://github.com/botpress/botpress-messenger/issues/16

![custom_payload_text](https://cloud.githubusercontent.com/assets/1237450/24131157/a0aea3f0-0dcb-11e7-8d23-16180732dbf9.png)

When defined with **YOUR_POSTBACK**:
![custom_payload_postback](https://cloud.githubusercontent.com/assets/1237450/24131162/a425f1fa-0dcb-11e7-9a7f-04dd231f9ead.png)
