### PR TITLE
Add download config button

### DIFF
--- a/src/views/index.jsx
+++ b/src/views/index.jsx
@@ -394,7 +394,7 @@ export default class MessengerModule extends React.Component {
                       value={this.state['targetAudienceCloseToSome']}
                       onChange={this.handleChange} />
                   <HelpBlock>Separate countries by commas. You must use a <a target="_blank" href="https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes">ISO-3361 Alpha 2 code</a>.</HelpBlock>
-                </Col>        
+                </Col>
               </FormGroup>
               :null
             }
@@ -524,6 +524,21 @@ export default class MessengerModule extends React.Component {
     </div>
   }
 
+  renderConfigView() {
+    return (
+        <FormGroup>
+          <Col componentClass={ControlLabel} sm={3}>
+            <Button
+              href="/api/botpress-messenger/config"
+              download="botpress-messenger.json" >
+              Download Config
+            </Button>
+          </Col>
+        </FormGroup>
+
+    )
+  }
+
   renderForm() {
     return (
       <Form horizontal>
@@ -556,6 +571,7 @@ export default class MessengerModule extends React.Component {
           <div>
             {this.renderTargetAudience()}
             {this.renderTrustedDomainList()}
+            {this.renderConfigView()}
           </div>
         </div>
       </Form>


### PR DESCRIPTION
Give users the ability to download their current config.  This can be
useful if you want to preserve the config, or be able to share it with
others.