### PR TITLE
Fix issue with payment testers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -228,7 +228,7 @@ module.exports = {
       })
 
       router.get('/users', (req, res)=> {
-        users.getAllUsers()
+        users.getAllUsers
           .then((values) => {
             res.send(values)
           })


### PR DESCRIPTION
During cleanup, Botpress changed the `users.getAllUsers` to be a
variable instead of a function.  The /users endpoint for the API broke
as a result.  This commit patches this error so that the /users endpoint
treats `users.getAllUsers` as a variable and not a function.