### PR TITLE
#60 add bp.events.emit call for module events

### DIFF
--- a/src/messenger.js
+++ b/src/messenger.js
@@ -540,6 +540,8 @@ class Messenger extends EventEmitter {
 
   _handleEvent(type, event) {
     this.emit(type, event)
+    // bubble up event to botpress.events
+    this.bp.events.emit(`messenger.${type}`, event)
   }
 
   _handleMessageEvent(event) {


### PR DESCRIPTION
addresses the issue #60 
* bubbles up events in the module by calling `bp.events.emit` and adding `messenger.` prefix to the event