### PR TITLE
Update text limit from 300 to 640

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -35,8 +35,8 @@ const validateUserId = (userId) => {
 }
 
 const validateText = (text) => {
-  if (typeof(text) !== 'string' || text.length > 300) {
-    throw new Error('Text must be a string less than 300 chars.')
+  if (typeof(text) !== 'string' || text.length > 640) {
+    throw new Error('Text must be a string less than 640 chars.')
   }
 }
 


### PR DESCRIPTION
Update text limit from the old one (300) to the new one (640) as seen on the docs :
https://developers.facebook.com/docs/messenger-platform/reference/send-api#request