### PR TITLE
update module to use helper.database from passed in bp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress-messenger",
-  "version": "2.2.9",
+  "version": "2.3.0",
   "description": "Official Facebook Messenger connector for botpress",
   "main": "bin/node.bundle.js",
   "homepage": "https://github.com/botpress/botpress-messenger",
@@ -16,11 +16,11 @@
     "botpress-connector"
   ],
   "version-manager": {
-    "date": "06/02/2017",
-    "warn": "Botpress 1.0 is now available.",
-    "botpress-check": ">= 0.1",
+    "date": "01/26/2018",
+    "warn": "Botpress 1.1.14 or later is required.",
+    "botpress-check": ">= 1.1.14",
     "botpress-update": "^1.0",
-    "module-downgrade": "~1.0.x"
+    "module-downgrade": "~1.1.x"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/db.js
+++ b/src/db.js
@@ -1,13 +1,11 @@
-import { DatabaseHelpers } from 'botpress'
-
 var knex = null
 
-function initialize() {
+function initialize(helpers) {
   if (!knex) {
     throw new Error('you must initialize the database before')
   }
-  
-  return DatabaseHelpers(knex).createTableIfNotExists('messenger_attachments', function (table) {
+
+  return helpers.database(knex).createTableIfNotExists('messenger_attachments', function (table) {
     table.string('url').primary()
     table.string('attachment_id')
   }).then()

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,10 @@ const outgoingMiddleware = (event, next) => {
   .then(setValue('resolve'), setValue('reject'))
 }
 
-const initializeMessenger = (bp, configurator) => {
+const initializeMessenger = (bp, configurator, helpers) => {
   return configurator.loadAll()
   .then(config => {
-    messenger = new Messenger(bp, config)
+    messenger = new Messenger(bp, config, helpers)
 
     users = Users(bp, messenger)
 
@@ -140,9 +140,9 @@ module.exports = {
     chatExtensionHomeUrl: { type: 'string', required: false, default: '' },
     chatExtensionInTest: { type: 'bool', required: false, default: true },
     chatExtensionShowShareButton: { type: 'bool', required: false, default: false },
-    webhookSubscriptionFields: { 
-      type: 'any', 
-      required: true, 
+    webhookSubscriptionFields: {
+      type: 'any',
+      required: true,
       default: [
         'message_deliveries',
         'message_reads',
@@ -194,8 +194,8 @@ module.exports = {
     UMM(bp) // Initializes Messenger in the UMM
   },
 
-  ready: function(bp, config) {
-    initializeMessenger(bp, config)
+  ready: function(bp, config, helpers) {
+    initializeMessenger(bp, config, helpers)
     .then(() => {
       incoming(bp, messenger)
 

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -24,7 +24,7 @@ const normalizeString = function(str) {
 let db = null
 
 class Messenger extends EventEmitter {
-  constructor(bp, config) {
+  constructor(bp, config, helpers) {
     super()
     if (!bp || !config) {
       throw new Error('You need to specify botpress and config')
@@ -36,7 +36,7 @@ class Messenger extends EventEmitter {
     bp.db.get()
     .then(k => {
       db = DB(k)
-      db.initialize()
+      db.initialize(helpers)
     })
 
     this.app = bp.getRouter('botpress-messenger', {


### PR DESCRIPTION
fix for: #75 and https://github.com/botpress/botpress/issues/396
* removed import of botpress module

This requires the updated `botpress` on npm be published, so do not merge/publish until latest version of `botpress` is `1.1.14` on npm